### PR TITLE
Use Ark.jl as the ECS Backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Vulkan = "9f14b124-c50e-4008-a7d4-969b3a6cd68a"
 glslang_jll = "6fd5517d-459c-5c5a-9b1a-c968b4e37a81"
+Ark = "56664e29-41e4-4ea5-ab0e-825499acc647"
 
 [compat]
 Base64 = "1.11.0"

--- a/src/OpenReality.jl
+++ b/src/OpenReality.jl
@@ -248,6 +248,55 @@ include("export/scene_export.jl")
 # Save/load serialization system
 include("serialization/save_load.jl")
 
+const COMPONENT_TYPES = DataType[
+    # Animation
+    AnimationComponent,
+    # Animation Blend Tree
+    AnimationBlendTreeComponent,
+    # Audio
+    AudioListenerComponent,
+    AudioSourceComponent,
+    # Camera
+    CameraComponent,
+    # Camera Controller
+    ThirdPersonCamera,
+    OrbitCamera,
+    CinematicCamera,
+    # Collider
+    ColliderComponent,
+    # Lights
+    PointLightComponent,
+    DirectionalLightComponent,
+    IBLComponent,
+    # Lod
+    LODComponent,
+    # Material
+    MaterialComponent,
+    # Mesh
+    MeshComponent,
+    # Particle System
+    ParticleSystemComponent,
+    # Player
+    PlayerComponent,
+    # Rigid Body
+    RigidBodyComponent,
+    # Script
+    ScriptComponent,
+    # Skeleton
+    BoneComponent,
+    SkinnedMeshComponent,
+    # Terrain
+    TerrainComponent,
+    # Transform
+    TransformComponent,
+    # Constraint
+    JointComponent,
+    # Trigger
+    TriggerComponent,
+    # Collision
+    CollisionCallbackComponent,
+]
+
 # Initialize the global Ark world with all components
 const _WORLD = initialize_world()
 

--- a/src/OpenReality.jl
+++ b/src/OpenReality.jl
@@ -1,6 +1,7 @@
 module OpenReality
 
 # Dependencies
+import Ark
 using Observables
 using GeometryBasics
 using ColorTypes
@@ -247,6 +248,9 @@ include("export/scene_export.jl")
 # Save/load serialization system
 include("serialization/save_load.jl")
 
+# Initialize the global Ark world with all components
+const _WORLD = initialize_world()
+
 # Export Threading
 export use_threading, threading_enabled
 
@@ -255,8 +259,9 @@ export EntityID, World, create_entity!, create_entity_id
 export Component, ComponentStore
 export add_component!, get_component, has_component, remove_component!
 export collect_components, entities_with_component, first_entity_with_component, component_count, iterate_components
-export register_component_type, reset_entity_counter!, reset_component_stores!, reset_engine_state!
+export reset_entity_counter!, reset_component_stores!, reset_engine_state!
 export queue_gpu_cleanup!, drain_gpu_cleanup_queue!, flush_gpu_cleanup!, cleanup_all_gpu_resources!
+export initialize_world
 
 # Export State
 export State, state

--- a/src/ecs.jl
+++ b/src/ecs.jl
@@ -1,6 +1,3 @@
-# Entity Component System Core
-# Implements entity ID generation, component storage, and component operations
-
 # =============================================================================
 # Entity ID System
 # =============================================================================
@@ -10,70 +7,83 @@
 
 Unique identifier for entities in the ECS.
 """
-const EntityID = UInt64
+const EntityID = Ark.Entity
 
-# Internal alias for backward compatibility
-const EntityId = EntityID
+# just for current tests TODO: remove this after adjusting tests
+####
+EntityID(x::Int) = Ark._new_entity(UInt32(x), UInt32(0))
+EntityID(x::Int, y::Int) = Ark._new_entity(UInt32(x), UInt32(y))
+Base.isless(a::EntityID, b::EntityID) = a._id < b._id
+####
 
-"""
-    EntityCounter
+function initialize_world(custom_components=[])
+    component_types = [
+        # Custom
+        custom_components...,
+        # Animation
+        AnimationComponent,
+        # Animation Blend Tree
+        AnimationBlendTreeComponent,
+        # Audio
+        AudioListenerComponent,
+        AudioSourceComponent,
+        # Camera
+        CameraComponent,
+        # Camera Controller
+        ThirdPersonCamera,
+        OrbitCamera,
+        CinematicCamera,
+        # Collider
+        ColliderComponent,
+        # Lights
+        PointLightComponent,
+        DirectionalLightComponent,
+        IBLComponent,
+        # Lod
+        LODComponent,
+        # Material
+        MaterialComponent,
+        # Mesh
+        MeshComponent,
+        # Particle System
+        ParticleSystemComponent,
+        # Player
+        PlayerComponent,
+        # Rigid Body
+        RigidBodyComponent,
+        # Script
+        ScriptComponent,
+        # Skeleton
+        BoneComponent,
+        SkinnedMeshComponent,
+        # Terrain
+        TerrainComponent,
+        # Transform
+        TransformComponent,
+        # Constraint
+        JointComponent,
+        # Trigger
+        TriggerComponent,
+        # Collision
+        CollisionCallbackComponent,
+    ]
 
-Mutable counter for generating unique entity IDs.
-"""
-mutable struct EntityCounter
-    next_id::EntityId
+    return Ark.World(component_types..., allow_mutable=true)
 end
-
-"""
-Global entity counter for unique ID generation.
-"""
-const ENTITY_COUNTER = EntityCounter(EntityId(1))
-
-"""
-    create_entity_id() -> EntityID
-
-Create a new unique entity ID using the global counter.
-"""
-function create_entity_id()::EntityID
-    id = ENTITY_COUNTER.next_id
-    ENTITY_COUNTER.next_id += 1
-    return id
-end
-
-"""
-    reset_entity_counter!()
-
-Reset the global entity counter. Useful for testing.
-"""
-function reset_entity_counter!()
-    ENTITY_COUNTER.next_id = EntityId(1)
-end
-
-# =============================================================================
-# World (for Scene compatibility)
-# =============================================================================
 
 """
     World
 
 Container for all entities and their components.
-Uses its own internal counter for entity creation.
 """
-mutable struct World
-    next_entity_id::EntityId
-
-    World() = new(EntityId(1))
-end
+World() = _WORLD
 
 """
     create_entity!(world::World) -> EntityID
-
-Create a new entity in the world using the world's internal counter.
 """
-function create_entity!(world::World)
-    id = world.next_entity_id
-    world.next_entity_id += 1
-    return id
+function create_entity!(world)
+    ark_entity = Ark.new_entity!(world, ())
+    return ark_entity
 end
 
 # =============================================================================
@@ -84,60 +94,39 @@ end
     Component
 
 Abstract base type for all components in the ECS.
-All component types must subtype this.
 """
 abstract type Component end
 
 # =============================================================================
-# Component Storage
+# Component Storage (Compatibility Layer)
 # =============================================================================
 
-"""
-    ComponentStore{T <: Component}
-
-Type-specific storage for components. Stores components in a contiguous array
-and maintains a mapping from entity IDs to array indices.
-"""
-mutable struct ComponentStore{T <: Component}
-    components::Vector{T}
-    entity_map::Dict{EntityId, Int}  # EntityId → index in components array
-    index_to_entity::Dict{Int, EntityId}  # Reverse mapping for removal
-
-    ComponentStore{T}() where T <: Component = new{T}(T[], Dict{EntityId, Int}(), Dict{Int, EntityId}())
+struct ComponentStore{T <: Component}
 end
 
-"""
-Global registry of component stores, keyed by component type.
-"""
 const COMPONENT_STORES = Dict{DataType, ComponentStore{<:Component}}()
 
 """
     reset_component_stores!()
-
-Reset all component stores. Useful for testing.
 """
+function reset_component_stores!()
+    world = World()
+    Ark.reset!(world)
+    empty!(_GPU_CLEANUP_QUEUE)
+    for hook in _RESET_HOOKS
+        hook()
+    end
+end
+
 const _RESET_HOOKS = Function[]
 
-# GPU cleanup queue — entities pending GPU resource removal.
-# Filled by `remove_entity()`, drained by `flush_gpu_cleanup!()` in the render loop.
 const _GPU_CLEANUP_QUEUE = EntityID[]
 
-"""
-    queue_gpu_cleanup!(entity_ids)
-
-Enqueue entity IDs for deferred GPU resource cleanup (meshes, bounds, etc.).
-Called automatically by `remove_entity()`; flushed once per frame by the render loop.
-"""
 function queue_gpu_cleanup!(entity_ids)
     append!(_GPU_CLEANUP_QUEUE, entity_ids)
     return nothing
 end
 
-"""
-    drain_gpu_cleanup_queue!() -> Vector{EntityID}
-
-Return all pending entity IDs and clear the queue.
-"""
 function drain_gpu_cleanup_queue!()::Vector{EntityID}
     if isempty(_GPU_CLEANUP_QUEUE)
         return EntityID[]
@@ -147,34 +136,8 @@ function drain_gpu_cleanup_queue!()::Vector{EntityID}
     return result
 end
 
-function reset_component_stores!()
-    empty!(COMPONENT_STORES)
-    empty!(_GPU_CLEANUP_QUEUE)
-    for hook in _RESET_HOOKS
-        hook()
-    end
-end
-
-"""
-    register_component_type(::Type{T}) where T <: Component
-
-Register a component type in the global registry.
-Creates a new ComponentStore if one doesn't already exist.
-"""
-function register_component_type(::Type{T}) where T <: Component
-    if !haskey(COMPONENT_STORES, T)
-        COMPONENT_STORES[T] = ComponentStore{T}()
-    end
-    return nothing
-end
-
-"""
-    get_component_store(::Type{T}) where T <: Component -> Union{ComponentStore{T}, Nothing}
-
-Get the component store for a specific type, or nothing if not registered.
-"""
-function get_component_store(::Type{T})::Union{ComponentStore{T}, Nothing} where T <: Component
-    return get(COMPONENT_STORES, T, nothing)
+function get_component_store(::Type{T}) where T <: Component
+    return ComponentStore{T}()
 end
 
 # =============================================================================
@@ -183,96 +146,45 @@ end
 
 """
     add_component!(entity_id::EntityID, component::T) where T <: Component
-
-Add a component to an entity. If the entity already has a component of this type,
-it will be replaced.
 """
-function add_component!(entity_id::EntityID, component::T) where T <: Component
-    # Ensure component type is registered
-    register_component_type(T)
-
-    store = COMPONENT_STORES[T]
-
-    # Check if entity already has this component type
-    if haskey(store.entity_map, entity_id)
-        # Replace existing component
-        idx = store.entity_map[entity_id]
-        store.components[idx] = component
-    else
-        # Add new component
-        push!(store.components, component)
-        idx = length(store.components)
-        store.entity_map[entity_id] = idx
-        store.index_to_entity[idx] = entity_id
+function add_component!(ark_entity::EntityID, component::T) where T <: Component
+    world = World()
+    if ark_entity === nothing
+        ark_entity = Ark.new_entity!(world, ())
     end
-
+    if Ark.has_components(world, ark_entity, (T,))
+        Ark.set_components!(world, ark_entity, (component,))
+    else
+        Ark.add_components!(world, ark_entity, (component,))
+    end
     return nothing
 end
 
 """
-    get_component(entity_id::EntityID, ::Type{T}) where T <: Component -> Union{T, Nothing}
-
-Get a component of the specified type for an entity.
-Returns nothing if the entity doesn't have this component type.
+    get_component(entity_id::EntityID, ::Type{T}) where T <: Component
 """
-function get_component(entity_id::EntityID, ::Type{T})::Union{T, Nothing} where T <: Component
-    store = get_component_store(T)
-    if store === nothing
+function get_component(ark_entity::EntityID, ::Type{T})::Union{T, Nothing} where T <: Component
+    world = World()
+    ark_entity === nothing && return nothing
+    if !Ark.has_components(world, ark_entity, (T,))
         return nothing
     end
-
-    idx = get(store.entity_map, entity_id, nothing)
-    return idx === nothing ? nothing : store.components[idx]
+    return Ark.get_components(world, ark_entity, (T,))[1]
 end
 
-"""
-    has_component(entity_id::EntityID, ::Type{T}) where T <: Component -> Bool
-
-Check if an entity has a component of the specified type.
-"""
-function has_component(entity_id::EntityID, ::Type{T})::Bool where T <: Component
-    store = get_component_store(T)
-    if store === nothing
-        return false
-    end
-    return haskey(store.entity_map, entity_id)
+function has_component(ark_entity::EntityID, ::Type{T})::Bool where T <: Component
+    world = World()
+    ark_entity === nothing && return false
+    return Ark.has_components(world, ark_entity, (T,))
 end
 
-"""
-    remove_component!(entity_id::EntityID, ::Type{T}) where T <: Component -> Bool
-
-Remove a component of the specified type from an entity.
-Returns true if the component was removed, false if the entity didn't have it.
-
-Uses swap-and-pop for O(1) removal while maintaining contiguous storage.
-"""
-function remove_component!(entity_id::EntityID, ::Type{T})::Bool where T <: Component
-    store = get_component_store(T)
-    if store === nothing
+function remove_component!(ark_entity::EntityID, ::Type{T})::Bool where T <: Component
+    world = World()
+    ark_entity === nothing && return false
+    if !Ark.has_components(world, ark_entity, (T,))
         return false
     end
-
-    idx = get(store.entity_map, entity_id, nothing)
-    if idx === nothing
-        return false
-    end
-
-    # Swap-and-pop removal for O(1) complexity
-    last_idx = length(store.components)
-
-    if idx != last_idx
-        # Move last element to the removed position
-        last_entity = store.index_to_entity[last_idx]
-        store.components[idx] = store.components[last_idx]
-        store.entity_map[last_entity] = idx
-        store.index_to_entity[idx] = last_entity
-    end
-
-    # Remove the last element
-    pop!(store.components)
-    delete!(store.entity_map, entity_id)
-    delete!(store.index_to_entity, last_idx)
-
+    Ark.remove_components!(world, ark_entity, (T,))
     return true
 end
 
@@ -281,89 +193,74 @@ end
 # =============================================================================
 
 """
-    collect_components(::Type{T}) where T <: Component -> Vector{T}
-
-Get all components of the specified type.
-Returns an empty vector if no components of this type exist.
+    collect_components(::Type{T}) where T <: Component
 """
 function collect_components(::Type{T})::Vector{T} where T <: Component
-    store = get_component_store(T)
-    if store === nothing
-        return T[]
+    world = World()
+    items = T[]
+    for (entities, col) in Ark.Query(world, (T,))
+        append!(items, col)
     end
-    return store.components
+    return items
 end
 
 """
-    entities_with_component(::Type{T}) where T <: Component -> Vector{EntityID}
-
-Get all entity IDs that have a component of the specified type.
-Returns an empty vector if no entities have this component type.
-Note: This allocates a new vector. For hot-path iteration, use `iterate_components` instead.
+    entities_with_component(::Type{T}) where T <: Component
 """
 function entities_with_component(::Type{T})::Vector{EntityID} where T <: Component
-    store = get_component_store(T)
-    if store === nothing
-        return EntityID[]
+    world = World()
+    ids = Ark.Entity[]
+    q = Ark.Query(world, (T,))
+    for (entities, _) in q
+        append!(ids, entities)
     end
-    return collect(keys(store.entity_map))
+    return ids
 end
 
 """
-    first_entity_with_component(::Type{T}) where T <: Component -> Union{EntityID, Nothing}
-
-Get the first entity ID with a component of the specified type, or nothing.
-Non-allocating alternative to `entities_with_component(...)[1]`.
+    first_entity_with_component(::Type{T}) where T <: Component
 """
 function first_entity_with_component(::Type{T})::Union{EntityID, Nothing} where T <: Component
-    store = get_component_store(T)
-    store === nothing && return nothing
-    isempty(store.entity_map) && return nothing
-    return first(keys(store.entity_map))
+    world = World()
+    q = Ark.Query(world, (T,))
+    for (entities, _) in q
+        Ark.close!(q)
+        return entities[1]
+    end
+    return nothing
 end
 
 """
-    component_count(::Type{T}) where T <: Component -> Int
-
-Get the number of entities with a component of the specified type.
+    component_count(::Type{T}) where T <: Component
 """
 function component_count(::Type{T})::Int where T <: Component
-    store = get_component_store(T)
-    if store === nothing
-        return 0
-    end
-    return length(store.components)
+    world = World()
+    q = Ark.Query(world, (T,))
+    count = Ark.count_entities(q)
+    Ark.close!(q)
+    return count
 end
 
 """
     iterate_components(f::Function, ::Type{T}) where T <: Component
-
-Iterate over all (entity_id, component) pairs for a component type.
-Calls f(entity_id, component) for each pair.
 """
 function iterate_components(f::Function, ::Type{T}) where T <: Component
-    store = get_component_store(T)
-    if store === nothing
-        return nothing
-    end
-
-    for (entity_id, idx) in store.entity_map
-        f(entity_id, store.components[idx])
+    world = World()
+    for (entities, cols...) in Ark.Query(world, (T,))
+        col = cols[1]
+        for i in eachindex(entities)
+            ark_ent = entities[i]
+            f(ark_ent, col[i])
+        end
     end
     return nothing
 end
 
 """
     reset_engine_state!()
-
-Reset all engine globals for scene switching. Clears ECS stores, entity counter,
-physics world, trigger state, particle pools, terrain cache, LOD cache,
-world transform cache, and asset manager cache. Audio device/context are
-intentionally excluded — use `clear_audio_sources!()` separately if needed.
 """
 function reset_engine_state!()
     reset_component_stores!()
-    reset_entity_counter!()
     reset_physics_world!()
     reset_trigger_state!()
     reset_particle_pools!()
@@ -373,7 +270,5 @@ function reset_engine_state!()
     reset_asset_manager!()
     reset_async_loader!()
     reset_event_bus!()
-    # AnimationBlendTreeComponent: no global stores — state is per-component,
-    # cleared automatically by reset_component_stores!() above.
     return nothing
 end

--- a/src/ecs.jl
+++ b/src/ecs.jl
@@ -17,58 +17,8 @@ Base.isless(a::EntityID, b::EntityID) = a._id < b._id
 ####
 
 function initialize_world(custom_components=[])
-    component_types = [
-        # Custom
-        custom_components...,
-        # Animation
-        AnimationComponent,
-        # Animation Blend Tree
-        AnimationBlendTreeComponent,
-        # Audio
-        AudioListenerComponent,
-        AudioSourceComponent,
-        # Camera
-        CameraComponent,
-        # Camera Controller
-        ThirdPersonCamera,
-        OrbitCamera,
-        CinematicCamera,
-        # Collider
-        ColliderComponent,
-        # Lights
-        PointLightComponent,
-        DirectionalLightComponent,
-        IBLComponent,
-        # Lod
-        LODComponent,
-        # Material
-        MaterialComponent,
-        # Mesh
-        MeshComponent,
-        # Particle System
-        ParticleSystemComponent,
-        # Player
-        PlayerComponent,
-        # Rigid Body
-        RigidBodyComponent,
-        # Script
-        ScriptComponent,
-        # Skeleton
-        BoneComponent,
-        SkinnedMeshComponent,
-        # Terrain
-        TerrainComponent,
-        # Transform
-        TransformComponent,
-        # Constraint
-        JointComponent,
-        # Trigger
-        TriggerComponent,
-        # Collision
-        CollisionCallbackComponent,
-    ]
-
-    return Ark.World(component_types..., allow_mutable=true)
+    types = [custom_components...; COMPONENT_TYPES]
+    return Ark.World(types..., allow_mutable=true)
 end
 
 """

--- a/src/export/scene_export.jl
+++ b/src/export/scene_export.jl
@@ -163,7 +163,9 @@ end
 function _write_entity_graph(io, entities, entity_index, parent_map,
                               mesh_index_map, material_index_map)
     for eid in entities
-        write(io, UInt64(eid))
+
+        # TODO: do not use internals of Ark
+        write(io, (UInt64(eid._id) >> 32) | UInt64(eid._gen))
 
         # Parent index (UInt32_MAX = root)
         parent_idx = haskey(parent_map, eid) ? entity_index[parent_map[eid]] : typemax(UInt32)

--- a/src/game/context.jl
+++ b/src/game/context.jl
@@ -27,7 +27,7 @@ Enqueue a new entity for deferred spawning.  Returns the pre-allocated
 `apply_mutations!` flush.
 """
 function spawn!(ctx::GameContext, entity_def::EntityDef)::EntityID
-    eid = create_entity_id()
+    eid = create_entity!(World())
     push!(ctx._spawn_queue, (eid, entity_def))
     return eid
 end

--- a/src/rendering/camera_utils.jl
+++ b/src/rendering/camera_utils.jl
@@ -7,13 +7,14 @@
 Find the first entity with a CameraComponent.
 """
 function find_active_camera()
-    store = get_component_store(CameraComponent)
-    store === nothing && return nothing
-    for (eid, idx) in store.entity_map
-        cam = store.components[idx]
-        cam.active && return eid
+    active_eid = nothing
+    iterate_components(CameraComponent) do eid, cam
+        if cam.active
+            active_eid = eid
+            return # This return is for the closure, not find_active_camera
+        end
     end
-    return nothing
+    return active_eid
 end
 
 """

--- a/src/scene.jl
+++ b/src/scene.jl
@@ -284,7 +284,7 @@ reference for hierarchical transform calculation.
 """
 function add_entity_from_def(scene::Scene, entity_def::EntityDef, parent::Union{EntityID, Nothing})::Scene
     # Create entity ID
-    entity_id = create_entity_id()
+    entity_id = create_entity!(World())
 
     # Add components to ECS storage
     for component in entity_def.components
@@ -555,7 +555,7 @@ Note: This returns the entity ID but doesn't update the scene (use scene(defs) i
 """
 function entity(scene_ref::Scene)
     @warn "Using entity(scene::Scene) is deprecated. Use scene([entity(...)]) syntax instead."
-    id = create_entity_id()
+    id = create_entity!(World())
     return id
 end
 
@@ -567,7 +567,7 @@ Deprecated: Use the new scene([entity(...)]) syntax instead.
 """
 function entity(scene_ref::Scene, f::Function)
     @warn "Using entity(scene::Scene, f::Function) is deprecated. Use scene([entity(...)]) syntax instead."
-    id = create_entity_id()
+    id = create_entity!(World())
     f(id)
     return id
 end

--- a/src/scene.jl
+++ b/src/scene.jl
@@ -105,11 +105,9 @@ function remove_entity(scene::Scene, entity_id::EntityID)::Scene
     queue_gpu_cleanup!(entities_to_remove)
 
     # Purge ECS components for all entities being removed
+    world = World()
     for eid in entities_to_remove
-        for (_, store) in COMPONENT_STORES
-            T = eltype(store.components)
-            remove_component!(eid, T)
-        end
+        Ark.remove_entity!(world, eid)
     end
 
     # Filter out removed entities

--- a/src/threading.jl
+++ b/src/threading.jl
@@ -60,13 +60,13 @@ Snapshot all TransformComponents into plain immutable structs.
 **Must be called on the main thread** (reads Observable values).
 """
 function snapshot_transforms()::Dict{EntityID, TransformSnapshot}
-    store = get(COMPONENT_STORES, TransformComponent, nothing)
-    store === nothing && return Dict{EntityID, TransformSnapshot}()
+    world = World()
     result = Dict{EntityID, TransformSnapshot}()
-    sizehint!(result, length(store.entity_map))
-    for (eid, idx) in store.entity_map
-        tc = store.components[idx]
-        result[eid] = TransformSnapshot(tc.position[], tc.rotation[], tc.scale[])
+    for (entities, transforms) in Ark.Query(world, (TransformComponent,))
+        for i in eachindex(entities)
+            tc = transforms[i]
+            result[entities[i]] = TransformSnapshot(tc.position[], tc.rotation[], tc.scale[])
+        end
     end
     return result
 end
@@ -79,12 +79,12 @@ For immutable component structs this is a lightweight copy.
 **Must be called on the main thread.**
 """
 function snapshot_components(::Type{T})::Dict{EntityID, T} where T <: Component
-    store = get(COMPONENT_STORES, T, nothing)
-    store === nothing && return Dict{EntityID, T}()
+    world = World()
     result = Dict{EntityID, T}()
-    sizehint!(result, length(store.entity_map))
-    for (eid, idx) in store.entity_map
-        result[eid] = store.components[idx]
+    for (entities, components) in Ark.Query(world, (T,))
+        for i in eachindex(entities)
+            result[entities[i]] = components[i]
+        end
     end
     return result
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,34 +13,30 @@ using StaticArrays
     @testset "ECS" begin
         @testset "World-based entity creation" begin
             world = World()
-            @test world.next_entity_id == 1
 
-            id1 = create_entity!(world)
-            @test id1 == 1
-            @test world.next_entity_id == 2
+            id1 = create_entity!(World())
+            @test id1._id == 2
 
-            id2 = create_entity!(world)
-            @test id2 == 2
+            id2 = create_entity!(World())
+            @test id2._id == 3
         end
 
         @testset "Global entity ID generation" begin
-            reset_entity_counter!()
-
-            id1 = create_entity_id()
-            id2 = create_entity_id()
+            id1 = create_entity!(World())
+            id2 = create_entity!(World())
 
             @test id1 != id2
-            @test id2 == id1 + 1
+            @test id2._id == id1._id + 1
             @test typeof(id1) == EntityID
         end
 
         @testset "Component storage" begin
             reset_component_stores!()
-            reset_entity_counter!()
+            
 
             # Create entities
-            e1 = create_entity_id()
-            e2 = create_entity_id()
+            e1 = create_entity!(World())
+            e2 = create_entity!(World())
 
             # Add components (using new Observable-based TransformComponent)
             add_component!(e1, transform(position=Vec3d(1, 2, 3)))
@@ -67,9 +63,9 @@ using StaticArrays
 
         @testset "Component replacement" begin
             reset_component_stores!()
-            reset_entity_counter!()
+            
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
 
             # Add initial component
             add_component!(e1, transform(position=Vec3d(1, 1, 1)))
@@ -85,11 +81,11 @@ using StaticArrays
 
         @testset "Component removal" begin
             reset_component_stores!()
-            reset_entity_counter!()
+            
 
-            e1 = create_entity_id()
-            e2 = create_entity_id()
-            e3 = create_entity_id()
+            e1 = create_entity!(World())
+            e2 = create_entity!(World())
+            e3 = create_entity!(World())
 
             add_component!(e1, transform(position=Vec3d(1, 0, 0)))
             add_component!(e2, transform(position=Vec3d(2, 0, 0)))
@@ -114,10 +110,10 @@ using StaticArrays
 
         @testset "Component iteration" begin
             reset_component_stores!()
-            reset_entity_counter!()
+            
 
-            e1 = create_entity_id()
-            e2 = create_entity_id()
+            e1 = create_entity!(World())
+            e2 = create_entity!(World())
 
             add_component!(e1, transform(position=Vec3d(1, 0, 0)))
             add_component!(e2, transform(position=Vec3d(2, 0, 0)))
@@ -139,9 +135,9 @@ using StaticArrays
 
         @testset "Multiple component types" begin
             reset_component_stores!()
-            reset_entity_counter!()
+            
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
 
             # Add multiple component types to same entity
             add_component!(e1, transform(position=Vec3d(1, 2, 3)))
@@ -182,11 +178,10 @@ using StaticArrays
         end
 
         @testset "Immutable Scene" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             s1 = Scene()
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
 
             s2 = add_entity(s1, e1)
 
@@ -202,13 +197,12 @@ using StaticArrays
         end
 
         @testset "Entity hierarchy" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             s = Scene()
-            parent_id = create_entity_id()
-            child1_id = create_entity_id()
-            child2_id = create_entity_id()
+            parent_id = create_entity!(World())
+            child1_id = create_entity!(World())
+            child2_id = create_entity!(World())
 
             # Build hierarchy: parent -> [child1, child2]
             s = add_entity(s, parent_id, nothing)
@@ -233,7 +227,6 @@ using StaticArrays
         end
 
         @testset "Scene construction with entity definitions" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Create scene with hierarchy using entity definitions
@@ -265,7 +258,6 @@ using StaticArrays
         end
 
         @testset "Single component entity convenience" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             s = scene([
@@ -279,7 +271,6 @@ using StaticArrays
         end
 
         @testset "Scene traversal" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Create a tree: root -> [child1 -> [grandchild], child2]
@@ -302,7 +293,7 @@ using StaticArrays
         end
 
         @testset "Scene traversal with depth" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
             # Create: root (depth 0) -> child (depth 1) -> grandchild (depth 2)
@@ -320,7 +311,7 @@ using StaticArrays
         end
 
         @testset "Get descendants and ancestors" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
             # Create: root -> child -> grandchild
@@ -350,7 +341,7 @@ using StaticArrays
         end
 
         @testset "Entity removal" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
             # Create: root1 -> [child1, child2], root2
@@ -381,7 +372,6 @@ using StaticArrays
         end
 
         @testset "Entity helper functions" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             s = scene([
@@ -407,7 +397,6 @@ using StaticArrays
         end
 
         @testset "Complex nested hierarchy" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Create a more complex tree
@@ -638,11 +627,10 @@ using StaticArrays
         end
 
         @testset "Collision resolution — floor prevents fall-through" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Create a floor (static, at y=0, extends from -10 to 10 in xz, height 0.1)
-            floor_id = create_entity_id()
+            floor_id = create_entity!(World())
             add_component!(floor_id, transform(position=Vec3d(0, -0.05, 0)))
             add_component!(floor_id, ColliderComponent(
                 shape=AABBShape(Vec3f(10.0, 0.05, 10.0))
@@ -650,7 +638,7 @@ using StaticArrays
             add_component!(floor_id, RigidBodyComponent(body_type=BODY_STATIC))
 
             # Create a dynamic box above the floor
-            box_id = create_entity_id()
+            box_id = create_entity!(World())
             add_component!(box_id, transform(position=Vec3d(0, 0.5, 0)))
             add_component!(box_id, ColliderComponent(
                 shape=AABBShape(Vec3f(0.5, 0.5, 0.5))
@@ -822,14 +810,13 @@ using StaticArrays
 
     @testset "Physics — Narrowphase" begin
         @testset "Sphere vs Sphere collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(1.0f0)))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(1.5, 0, 0)))
             add_component!(e2, ColliderComponent(shape=SphereShape(1.0f0)))
 
@@ -842,14 +829,13 @@ using StaticArrays
         end
 
         @testset "Sphere vs Sphere no collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(0.5f0)))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(5, 0, 0)))
             add_component!(e2, ColliderComponent(shape=SphereShape(0.5f0)))
 
@@ -858,14 +844,13 @@ using StaticArrays
         end
 
         @testset "AABB vs AABB collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=AABBShape(Vec3f(1, 1, 1))))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(1.5, 0, 0)))
             add_component!(e2, ColliderComponent(shape=AABBShape(Vec3f(1, 1, 1))))
 
@@ -875,14 +860,13 @@ using StaticArrays
         end
 
         @testset "Sphere vs AABB collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(1.0f0)))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(1.5, 0, 0)))
             add_component!(e2, ColliderComponent(shape=AABBShape(Vec3f(1, 1, 1))))
 
@@ -892,14 +876,13 @@ using StaticArrays
         end
 
         @testset "Capsule vs Sphere collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=CapsuleShape(radius=0.5f0, half_height=1.0f0)))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(0.8, 0, 0)))
             add_component!(e2, ColliderComponent(shape=SphereShape(0.5f0)))
 
@@ -909,14 +892,13 @@ using StaticArrays
         end
 
         @testset "Capsule vs Capsule collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=CapsuleShape(radius=0.3f0, half_height=0.5f0)))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(0.4, 0, 0)))
             add_component!(e2, ColliderComponent(shape=CapsuleShape(radius=0.3f0, half_height=0.5f0)))
 
@@ -926,14 +908,13 @@ using StaticArrays
         end
 
         @testset "Capsule vs AABB collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 1, 0)))
             add_component!(e1, ColliderComponent(shape=CapsuleShape(radius=0.5f0, half_height=0.5f0)))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(0, 0, 0)))
             add_component!(e2, ColliderComponent(shape=AABBShape(Vec3f(2, 0.5, 2))))
 
@@ -944,14 +925,13 @@ using StaticArrays
 
     @testset "Physics — GJK/EPA" begin
         @testset "OBB vs AABB collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=OBBShape(Vec3f(1, 1, 1))))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(1.5, 0, 0)))
             add_component!(e2, ColliderComponent(shape=AABBShape(Vec3f(1, 1, 1))))
 
@@ -961,14 +941,13 @@ using StaticArrays
         end
 
         @testset "OBB vs OBB collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=OBBShape(Vec3f(1, 1, 1))))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(1.5, 0, 0)))
             add_component!(e2, ColliderComponent(shape=OBBShape(Vec3f(1, 1, 1))))
 
@@ -977,17 +956,16 @@ using StaticArrays
         end
 
         @testset "ConvexHull vs AABB collision" begin
-            reset_entity_counter!()
-            reset_component_stores!()
+           reset_component_stores!()
 
             # Tetrahedron centered at origin
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=ConvexHullShape([
                 Vec3f(0, 1, 0), Vec3f(-1, -1, 0), Vec3f(1, -1, 0), Vec3f(0, 0, -1)
             ])))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(0.5, 0, 0)))
             add_component!(e2, ColliderComponent(shape=AABBShape(Vec3f(1, 1, 1))))
 
@@ -996,16 +974,15 @@ using StaticArrays
         end
 
         @testset "ConvexHull vs ConvexHull no collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=ConvexHullShape([
                 Vec3f(0, 1, 0), Vec3f(-1, -1, 0), Vec3f(1, -1, 0), Vec3f(0, 0, -1)
             ])))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(10, 0, 0)))
             add_component!(e2, ColliderComponent(shape=ConvexHullShape([
                 Vec3f(0, 1, 0), Vec3f(-1, -1, 0), Vec3f(1, -1, 0), Vec3f(0, 0, -1)
@@ -1032,10 +1009,9 @@ using StaticArrays
 
     @testset "Physics — Raycasting" begin
         @testset "Raycast hits sphere" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, -5)))
             add_component!(e1, ColliderComponent(shape=SphereShape(1.0f0)))
 
@@ -1047,10 +1023,9 @@ using StaticArrays
         end
 
         @testset "Raycast hits AABB" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, -2, 0)))
             add_component!(e1, ColliderComponent(shape=AABBShape(Vec3f(10, 0.5, 10))))
 
@@ -1061,10 +1036,9 @@ using StaticArrays
         end
 
         @testset "Raycast misses" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(10, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(1.0f0)))
 
@@ -1073,10 +1047,9 @@ using StaticArrays
         end
 
         @testset "Raycast hits capsule" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, -5)))
             add_component!(e1, ColliderComponent(shape=CapsuleShape(radius=0.5f0, half_height=1.0f0)))
 
@@ -1086,10 +1059,9 @@ using StaticArrays
         end
 
         @testset "Raycast skips triggers" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, -3)))
             add_component!(e1, ColliderComponent(shape=SphereShape(1.0f0), is_trigger=true))
 
@@ -1098,14 +1070,13 @@ using StaticArrays
         end
 
         @testset "raycast_all returns sorted hits" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, -3)))
             add_component!(e1, ColliderComponent(shape=SphereShape(0.5f0)))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(0, 0, -8)))
             add_component!(e2, ColliderComponent(shape=SphereShape(0.5f0)))
 
@@ -1119,16 +1090,15 @@ using StaticArrays
 
     @testset "Physics — CCD" begin
         @testset "Sweep test detects collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Static wall close to origin
-            wall_id = create_entity_id()
+            wall_id = create_entity!(World())
             add_component!(wall_id, transform(position=Vec3d(1, 0, 0)))
             add_component!(wall_id, ColliderComponent(shape=AABBShape(Vec3f(0.1, 2, 2))))
 
             # Fast-moving sphere
-            bullet_id = create_entity_id()
+            bullet_id = create_entity!(World())
             add_component!(bullet_id, transform(position=Vec3d(0, 0, 0)))
             add_component!(bullet_id, ColliderComponent(shape=SphereShape(0.2f0)))
             add_component!(bullet_id, RigidBodyComponent(body_type=BODY_DYNAMIC, mass=0.5))
@@ -1190,18 +1160,17 @@ using StaticArrays
         end
 
         @testset "Ball-socket joint constrains pendulum" begin
-            reset_entity_counter!()
             reset_component_stores!()
             reset_physics_world!()
 
             # Static anchor
-            anchor = create_entity_id()
+            anchor = create_entity!(World())
             add_component!(anchor, transform(position=Vec3d(0, 5, 0)))
             add_component!(anchor, ColliderComponent(shape=SphereShape(0.1f0)))
             add_component!(anchor, RigidBodyComponent(body_type=BODY_STATIC))
 
             # Dynamic bob
-            bob = create_entity_id()
+            bob = create_entity!(World())
             add_component!(bob, transform(position=Vec3d(0, 3, 0)))
             add_component!(bob, ColliderComponent(shape=SphereShape(0.3f0)))
             add_component!(bob, RigidBodyComponent(body_type=BODY_DYNAMIC, mass=1.0,
@@ -1251,13 +1220,12 @@ using StaticArrays
         end
 
         @testset "Trigger enter/exit detection" begin
-            reset_entity_counter!()
             reset_component_stores!()
             reset_physics_world!()
             OpenReality.reset_trigger_state!()
 
             # Trigger zone at origin
-            trigger_eid = create_entity_id()
+            trigger_eid = create_entity!(World())
             add_component!(trigger_eid, transform(position=Vec3d(0, 0, 0)))
             add_component!(trigger_eid, ColliderComponent(
                 shape=AABBShape(Vec3f(2, 2, 2)), is_trigger=true
@@ -1271,7 +1239,7 @@ using StaticArrays
             ))
 
             # Object inside trigger zone
-            obj_eid = create_entity_id()
+            obj_eid = create_entity!(World())
             add_component!(obj_eid, transform(position=Vec3d(0, 0, 0)))
             add_component!(obj_eid, ColliderComponent(shape=SphereShape(0.5f0)))
 
@@ -1301,22 +1269,21 @@ using StaticArrays
         end
 
         @testset "build_islands groups connected bodies" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Two dynamic bodies with a contact manifold between them
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(1.0f0)))
             add_component!(e1, RigidBodyComponent(body_type=BODY_DYNAMIC))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(1, 0, 0)))
             add_component!(e2, ColliderComponent(shape=SphereShape(1.0f0)))
             add_component!(e2, RigidBodyComponent(body_type=BODY_DYNAMIC))
 
             # Isolated body
-            e3 = create_entity_id()
+            e3 = create_entity!(World())
             add_component!(e3, transform(position=Vec3d(100, 0, 0)))
             add_component!(e3, ColliderComponent(shape=SphereShape(1.0f0)))
             add_component!(e3, RigidBodyComponent(body_type=BODY_DYNAMIC))
@@ -1341,17 +1308,16 @@ using StaticArrays
 
     @testset "Physics — Compound Shapes" begin
         @testset "CompoundShape vs AABB collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=CompoundShape([
                 CompoundChild(AABBShape(Vec3f(0.5, 0.25, 0.25)), position=Vec3d(0, 0.25, 0)),
                 CompoundChild(AABBShape(Vec3f(0.25, 0.5, 0.25)), position=Vec3d(-0.25, -0.25, 0))
             ])))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(0.5, 0.25, 0)))
             add_component!(e2, ColliderComponent(shape=AABBShape(Vec3f(0.5, 0.5, 0.5))))
 
@@ -1360,16 +1326,15 @@ using StaticArrays
         end
 
         @testset "CompoundShape vs Sphere collision" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=CompoundShape([
                 CompoundChild(SphereShape(0.5f0), position=Vec3d(0, 0, 0))
             ])))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(0.8, 0, 0)))
             add_component!(e2, ColliderComponent(shape=SphereShape(0.5f0)))
 
@@ -1378,16 +1343,15 @@ using StaticArrays
         end
 
         @testset "CompoundShape no collision when distant" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=CompoundShape([
                 CompoundChild(AABBShape(Vec3f(0.5, 0.5, 0.5)), position=Vec3d(0, 0, 0))
             ])))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, transform(position=Vec3d(100, 0, 0)))
             add_component!(e2, ColliderComponent(shape=SphereShape(0.5f0)))
 
@@ -1441,11 +1405,10 @@ using StaticArrays
 
     @testset "Physics — Solver integration" begin
         @testset "Dynamic body falls under gravity" begin
-            reset_entity_counter!()
             reset_component_stores!()
             reset_physics_world!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 10, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(0.5f0)))
             add_component!(e1, RigidBodyComponent(body_type=BODY_DYNAMIC, mass=1.0))
@@ -1459,11 +1422,10 @@ using StaticArrays
         end
 
         @testset "Static body does not move" begin
-            reset_entity_counter!()
             reset_component_stores!()
             reset_physics_world!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(0, 5, 0)))
             add_component!(e1, ColliderComponent(shape=AABBShape(Vec3f(1, 1, 1))))
             add_component!(e1, RigidBodyComponent(body_type=BODY_STATIC))
@@ -1477,24 +1439,23 @@ using StaticArrays
         end
 
         @testset "Restitution: bouncy ball bounces higher" begin
-            reset_entity_counter!()
             reset_component_stores!()
             reset_physics_world!()
 
             # Floor
-            floor_id = create_entity_id()
+            floor_id = create_entity!(World())
             add_component!(floor_id, transform(position=Vec3d(0, -0.5, 0)))
             add_component!(floor_id, ColliderComponent(shape=AABBShape(Vec3f(10, 0.5, 10))))
             add_component!(floor_id, RigidBodyComponent(body_type=BODY_STATIC))
 
             # Low-bounce ball
-            b1 = create_entity_id()
+            b1 = create_entity!(World())
             add_component!(b1, transform(position=Vec3d(-2, 3, 0)))
             add_component!(b1, ColliderComponent(shape=SphereShape(0.3f0)))
             add_component!(b1, RigidBodyComponent(body_type=BODY_DYNAMIC, mass=1.0, restitution=0.1f0))
 
             # High-bounce ball
-            b2 = create_entity_id()
+            b2 = create_entity!(World())
             add_component!(b2, transform(position=Vec3d(2, 3, 0)))
             add_component!(b2, ColliderComponent(shape=SphereShape(0.3f0)))
             add_component!(b2, RigidBodyComponent(body_type=BODY_DYNAMIC, mass=1.0, restitution=0.9f0))
@@ -1694,10 +1655,9 @@ using StaticArrays
 
     @testset "Hierarchical Transforms" begin
         @testset "World transform for entity without parent" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(position=Vec3d(10, 0, 0)))
 
             world = get_world_transform(e1)
@@ -1709,10 +1669,9 @@ using StaticArrays
         end
 
         @testset "World transform for entity without transform" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             # No transform component added
 
             world = get_world_transform(e1)
@@ -1722,7 +1681,6 @@ using StaticArrays
         end
 
         @testset "Hierarchical transforms with parent-child" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Create parent-child hierarchy via scene
@@ -1747,7 +1705,6 @@ using StaticArrays
         end
 
         @testset "Three-level hierarchy" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Create grandparent -> parent -> child hierarchy
@@ -1777,7 +1734,6 @@ using StaticArrays
         end
 
         @testset "Hierarchical transforms with scale" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Parent scaled 2x, child at local position (5, 0, 0)
@@ -1798,7 +1754,6 @@ using StaticArrays
         end
 
         @testset "Hierarchical transforms with rotation" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Parent rotated 90° around Z axis
@@ -1823,10 +1778,9 @@ using StaticArrays
         end
 
         @testset "Local transform calculation" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, transform(
                 position=Vec3d(1, 2, 3),
                 scale=Vec3d(2, 2, 2)
@@ -2040,11 +1994,10 @@ using StaticArrays
         end
 
         @testset "update_animations! moves position" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Create entity with transform
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, transform(position=Vec3d(0, 0, 0)))
 
             # Create animation that moves x from 0 to 10 over 1 second
@@ -2513,13 +2466,12 @@ using StaticArrays
 
         @testset "Audio components in ECS" begin
             reset_component_stores!()
-            reset_entity_counter!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, AudioListenerComponent(gain=0.9f0))
             add_component!(e1, transform())
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, AudioSourceComponent(audio_path="sfx.wav", playing=true))
             add_component!(e2, transform(position=Vec3d(5, 0, 0)))
 
@@ -3078,14 +3030,13 @@ using StaticArrays
         end
 
         @testset "Bone matrix computation — identity" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
             # Create a mesh entity and a bone entity at the same position
-            mesh_eid = create_entity_id()
+            mesh_eid = create_entity!(World())
             add_component!(mesh_eid, transform(position=Vec3d(0, 0, 0)))
 
-            bone_eid = create_entity_id()
+            bone_eid = create_entity!(World())
             add_component!(bone_eid, transform(position=Vec3d(0, 0, 0)))
             add_component!(bone_eid, BoneComponent(
                 inverse_bind_matrix=Mat4f(I),
@@ -3107,13 +3058,12 @@ using StaticArrays
         end
 
         @testset "Bone matrix computation — translated bone" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            mesh_eid = create_entity_id()
+            mesh_eid = create_entity!(World())
             add_component!(mesh_eid, transform(position=Vec3d(0, 0, 0)))
 
-            bone_eid = create_entity_id()
+            bone_eid = create_entity!(World())
             add_component!(bone_eid, transform(position=Vec3d(5, 0, 0)))
             add_component!(bone_eid, BoneComponent(
                 inverse_bind_matrix=Mat4f(I),
@@ -3138,13 +3088,12 @@ using StaticArrays
         end
 
         @testset "Bone matrix with inverse bind matrix" begin
-            reset_entity_counter!()
             reset_component_stores!()
 
-            mesh_eid = create_entity_id()
+            mesh_eid = create_entity!(World())
             add_component!(mesh_eid, transform(position=Vec3d(0, 0, 0)))
 
-            bone_eid = create_entity_id()
+            bone_eid = create_entity!(World())
             add_component!(bone_eid, transform(position=Vec3d(3, 0, 0)))
 
             # IBM that undoes the bind pose translation
@@ -3176,17 +3125,17 @@ using StaticArrays
         end
 
         @testset "Multi-bone skinning" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
-            mesh_eid = create_entity_id()
+            mesh_eid = create_entity!(World())
             add_component!(mesh_eid, transform(position=Vec3d(0, 0, 0)))
 
-            bone1 = create_entity_id()
+            bone1 = create_entity!(World())
             add_component!(bone1, transform(position=Vec3d(1, 0, 0)))
             add_component!(bone1, BoneComponent(bone_index=0, name="bone1"))
 
-            bone2 = create_entity_id()
+            bone2 = create_entity!(World())
             add_component!(bone2, transform(position=Vec3d(0, 2, 0)))
             add_component!(bone2, BoneComponent(bone_index=1, name="bone2"))
 
@@ -3206,7 +3155,7 @@ using StaticArrays
         end
 
         @testset "update_skinned_meshes! with no skinned entities" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
             # Should not error with no skinned entities
@@ -3215,13 +3164,13 @@ using StaticArrays
         end
 
         @testset "Bone and skin components in ECS" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
-            e1 = create_entity_id()
+            e1 = create_entity!(World())
             add_component!(e1, BoneComponent(bone_index=0, name="root"))
 
-            e2 = create_entity_id()
+            e2 = create_entity!(World())
             add_component!(e2, SkinnedMeshComponent(bone_entities=[e1]))
 
             @test has_component(e1, BoneComponent)
@@ -3239,13 +3188,13 @@ using StaticArrays
         end
 
         @testset "Skinning resizes bone_matrices if needed" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
-            mesh_eid = create_entity_id()
+            mesh_eid = create_entity!(World())
             add_component!(mesh_eid, transform())
 
-            bone_eid = create_entity_id()
+            bone_eid = create_entity!(World())
             add_component!(bone_eid, transform())
             add_component!(bone_eid, BoneComponent(bone_index=0))
 
@@ -3325,10 +3274,10 @@ using StaticArrays
         end
 
         @testset "ParticleSystemComponent in ECS" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
-            eid = create_entity_id()
+            eid = create_entity!(World())
             comp = ParticleSystemComponent(emission_rate=30.0f0)
             add_component!(eid, comp)
 
@@ -3356,7 +3305,7 @@ using StaticArrays
         end
 
         @testset "Particle emission" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_particle_pools!()
 
@@ -3377,7 +3326,7 @@ using StaticArrays
         end
 
         @testset "Particle simulation" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
             comp = ParticleSystemComponent(
@@ -3504,7 +3453,7 @@ using StaticArrays
         end
 
         @testset "update_particles! with no emitters" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_particle_pools!()
 
@@ -3514,11 +3463,11 @@ using StaticArrays
         end
 
         @testset "Full particle update cycle" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_particle_pools!()
 
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, transform(position=Vec3d(0, 5, 0)))
             add_component!(eid, ParticleSystemComponent(
                 max_particles=50,
@@ -3546,11 +3495,11 @@ using StaticArrays
         end
 
         @testset "Particle pool cleanup on entity removal" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_particle_pools!()
 
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, transform())
             add_component!(eid, ParticleSystemComponent(burst_count=5))
 
@@ -3567,11 +3516,11 @@ using StaticArrays
         end
 
         @testset "Inactive emitter skipped" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_particle_pools!()
 
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, transform())
             comp = ParticleSystemComponent(burst_count=5, _active=false)
             add_component!(eid, comp)
@@ -3594,7 +3543,7 @@ using StaticArrays
         end
 
         @testset "Empty scene export roundtrip" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
             s = scene()
@@ -3617,10 +3566,10 @@ using StaticArrays
         end
 
         @testset "Single entity export" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, transform(position=Vec3d(1.0, 2.0, 3.0)))
             s = add_entity(scene(), eid)
 
@@ -3633,17 +3582,17 @@ using StaticArrays
                 @test reinterpret(UInt32, data[13:16])[1] == UInt32(1)
                 # Entity ID should be in the entity graph section (starts at byte 33)
                 eid_bytes = reinterpret(UInt64, data[33:40])[1]
-                @test eid_bytes == UInt64(eid)
+                @test eid_bytes == ((UInt64(eid._id) >> 32) | UInt64(eid._gen))
             finally
                 isfile(tmp) && rm(tmp)
             end
         end
 
         @testset "Entity with mesh and material" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, transform())
             add_component!(eid, MeshComponent(
                 vertices=[Point3f(0,0,0), Point3f(1,0,0), Point3f(0,1,0)],
@@ -3675,7 +3624,7 @@ using StaticArrays
         end
 
         @testset "Physics config export" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
             s = scene()
@@ -3696,10 +3645,10 @@ using StaticArrays
         end
 
         @testset "Entity with lights" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
 
-            eid1 = create_entity_id()
+            eid1 = create_entity!(World())
             add_component!(eid1, transform(position=Vec3d(5.0, 10.0, 5.0)))
             add_component!(eid1, PointLightComponent(
                 color=RGB{Float32}(1.0, 1.0, 1.0),
@@ -3707,7 +3656,7 @@ using StaticArrays
                 range=50.0f0
             ))
 
-            eid2 = create_entity_id()
+            eid2 = create_entity!(World())
             add_component!(eid2, transform())
             add_component!(eid2, DirectionalLightComponent(
                 direction=Vec3f(0.0, -1.0, 0.0),
@@ -3759,15 +3708,14 @@ using StaticArrays
     @testset "Engine Reset" begin
         @testset "reset_engine_state! clears ECS and physics" begin
             reset_component_stores!()
-            reset_entity_counter!()
-            eid = create_entity_id()
+            
+            eid = create_entity!(World())
             add_component!(eid, TransformComponent())
             @test component_count(TransformComponent) == 1
 
             reset_engine_state!()
 
             @test component_count(TransformComponent) == 0
-            @test OpenReality.ENTITY_COUNTER.next_id == 1
             @test OpenReality._PHYSICS_WORLD[] === nothing
         end
 
@@ -3808,7 +3756,7 @@ using StaticArrays
             reset_engine_state!()
             start_count = Ref(0)
             update_count = Ref(0)
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, ScriptComponent(
                 on_start = (_, _) -> start_count[] += 1,
                 on_update = (_, _, _) -> update_count[] += 1
@@ -3823,11 +3771,11 @@ using StaticArrays
         @testset "Error isolation" begin
             reset_engine_state!()
             counter = Ref(0)
-            eid1 = create_entity_id()
+            eid1 = create_entity!(World())
             add_component!(eid1, ScriptComponent(
                 on_update = (_, _, _) -> error("boom")
             ))
-            eid2 = create_entity_id()
+            eid2 = create_entity!(World())
             add_component!(eid2, ScriptComponent(
                 on_update = (_, _, _) -> counter[] += 1
             ))
@@ -3838,10 +3786,10 @@ using StaticArrays
 
         @testset "Snapshot protection" begin
             reset_engine_state!()
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, ScriptComponent(
                 on_update = (_, _, _) -> begin
-                    new_eid = create_entity_id()
+                    new_eid = create_entity!(World())
                     add_component!(new_eid, ScriptComponent(
                         on_update = (_, _, _) -> nothing
                     ))
@@ -3854,7 +3802,7 @@ using StaticArrays
         @testset "destroy_entity! fires on_destroy before removal" begin
             reset_engine_state!()
             destroy_count = Ref(0)
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, ScriptComponent(
                 on_destroy = (_, _) -> destroy_count[] += 1
             ))
@@ -3868,8 +3816,8 @@ using StaticArrays
         @testset "destroy_entity! fires on_destroy for descendants" begin
             reset_engine_state!()
             child_destroy_count = Ref(0)
-            parent_eid = create_entity_id()
-            child_eid = create_entity_id()
+            parent_eid = create_entity!(World())
+            child_eid = create_entity!(World())
             add_component!(child_eid, ScriptComponent(
                 on_destroy = (_, _) -> child_destroy_count[] += 1
             ))
@@ -3883,7 +3831,7 @@ using StaticArrays
         @testset "remove_entity does NOT fire on_destroy" begin
             reset_engine_state!()
             destroy_count = Ref(0)
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, ScriptComponent(
                 on_destroy = (_, _) -> destroy_count[] += 1
             ))
@@ -3896,7 +3844,7 @@ using StaticArrays
         @testset "on_update receives GameContext" begin
             reset_engine_state!()
             received_ctx = Ref{Any}(nothing)
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, ScriptComponent(
                 on_update = (_, _, c) -> (received_ctx[] = c)
             ))
@@ -3915,12 +3863,12 @@ using StaticArrays
         end
 
         @testset "enter detection" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_physics_world!()
 
-            e1 = create_entity_id()
-            e2 = create_entity_id()
+            e1 = create_entity!(World())
+            e2 = create_entity!(World())
 
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(0.5f0)))
@@ -3944,12 +3892,12 @@ using StaticArrays
         end
 
         @testset "stay detection" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_physics_world!()
 
-            e1 = create_entity_id()
-            e2 = create_entity_id()
+            e1 = create_entity!(World())
+            e2 = create_entity!(World())
 
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(0.5f0)))
@@ -3974,12 +3922,12 @@ using StaticArrays
         end
 
         @testset "exit detection" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_physics_world!()
 
-            e1 = create_entity_id()
-            e2 = create_entity_id()
+            e1 = create_entity!(World())
+            e2 = create_entity!(World())
 
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(0.5f0)))
@@ -4003,12 +3951,12 @@ using StaticArrays
         end
 
         @testset "sleeping suppression" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_physics_world!()
 
-            e1 = create_entity_id()
-            e2 = create_entity_id()
+            e1 = create_entity!(World())
+            e2 = create_entity!(World())
 
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(0.5f0)))
@@ -4032,12 +3980,12 @@ using StaticArrays
         end
 
         @testset "callback error isolation" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_physics_world!()
 
-            e1 = create_entity_id()
-            e2 = create_entity_id()
+            e1 = create_entity!(World())
+            e2 = create_entity!(World())
 
             add_component!(e1, transform(position=Vec3d(0, 0, 0)))
             add_component!(e1, ColliderComponent(shape=SphereShape(0.5f0)))
@@ -4064,19 +4012,19 @@ using StaticArrays
         end
 
         @testset "integration: enter fires on collision" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             reset_physics_world!()
             OpenReality.reset_trigger_state!()
 
             # Dynamic sphere above static floor
-            sphere_eid = create_entity_id()
+            sphere_eid = create_entity!(World())
             add_component!(sphere_eid, transform(position=Vec3d(0, 1, 0)))
             add_component!(sphere_eid, ColliderComponent(shape=SphereShape(0.5f0)))
             add_component!(sphere_eid, RigidBodyComponent(mass=1.0))
             OpenReality.initialize_rigidbody_inertia!(sphere_eid)
 
-            floor_eid = create_entity_id()
+            floor_eid = create_entity!(World())
             add_component!(floor_eid, transform(position=Vec3d(0, 0, 0)))
             add_component!(floor_eid, ColliderComponent(shape=AABBShape(Vec3f(10, 0.1, 10))))
             add_component!(floor_eid, RigidBodyComponent(body_type=BODY_STATIC, mass=0.0))
@@ -4104,7 +4052,7 @@ using StaticArrays
         @testset "update_scripts! callable in full module context" begin
             reset_engine_state!()
             counter = Ref(0)
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, ScriptComponent(on_update=(id, dt) -> counter[] += 1))
             update_scripts!(0.016)
             @test counter[] == 1
@@ -4157,8 +4105,8 @@ using StaticArrays
             reset_engine_state!()
 
             # Create two target entities with transforms
-            target_a = create_entity_id()
-            target_b = create_entity_id()
+            target_a = create_entity!(World())
+            target_b = create_entity!(World())
             add_component!(target_a, transform(position=Vec3d(0, 0, 0)))
             add_component!(target_b, transform(position=Vec3d(0, 0, 0)))
 
@@ -4235,8 +4183,8 @@ using StaticArrays
 
         @testset "Guard: update_animations! skips blend-tree entities" begin
             reset_engine_state!()
-            eid = create_entity_id()
-            target_eid = create_entity_id()
+            eid = create_entity!(World())
+            target_eid = create_entity!(World())
             add_component!(target_eid, transform(position=Vec3d(0, 0, 0)))
 
             clip = AnimationClip("test", [
@@ -4267,7 +4215,7 @@ using StaticArrays
 
         @testset "Trigger consumed after evaluation" begin
             reset_engine_state!()
-            eid = create_entity_id()
+            eid = create_entity!(World())
             add_component!(eid, transform(position=Vec3d(0, 0, 0)))
 
             comp = AnimationBlendTreeComponent(
@@ -4294,11 +4242,11 @@ using StaticArrays
     @testset "Camera Controllers" begin
         @testset "find_active_camera with two cameras" begin
             reset_engine_state!()
-            eid1 = create_entity_id()
+            eid1 = create_entity!(World())
             add_component!(eid1, transform())
             add_component!(eid1, CameraComponent(active=false))
 
-            eid2 = create_entity_id()
+            eid2 = create_entity!(World())
             add_component!(eid2, transform())
             add_component!(eid2, CameraComponent(active=true))
 
@@ -4310,11 +4258,11 @@ using StaticArrays
             reset_engine_state!()
 
             # Target entity at origin
-            target_eid = create_entity_id()
+            target_eid = create_entity!(World())
             add_component!(target_eid, transform(position=Vec3d(0, 0, 0)))
 
             # Camera entity at origin
-            cam_eid = create_entity_id()
+            cam_eid = create_entity!(World())
             add_component!(cam_eid, transform(position=Vec3d(0, 0, 0)))
             add_component!(cam_eid, ThirdPersonCamera(
                 target_eid,
@@ -4344,7 +4292,7 @@ using StaticArrays
         @testset "CinematicCamera path interpolation" begin
             reset_engine_state!()
 
-            cam_eid = create_entity_id()
+            cam_eid = create_entity!(World())
             add_component!(cam_eid, transform(position=Vec3d(0, 0, 0)))
             add_component!(cam_eid, CinematicCamera(
                 5.0f0,                                    # move_speed
@@ -4490,11 +4438,11 @@ using StaticArrays
     end
 
     @testset "GameContext" begin
-        reset_entity_counter!()
+        
         reset_component_stores!()
 
         @testset "spawn! returns non-zero EntityID" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             s = Scene()
             ctx = GameContext(s, InputState())
@@ -4504,7 +4452,7 @@ using StaticArrays
         end
 
         @testset "spawned entity not in scene before apply_mutations!" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             s = Scene()
             ctx = GameContext(s, InputState())
@@ -4514,7 +4462,7 @@ using StaticArrays
         end
 
         @testset "spawned entity in scene after apply_mutations!" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             s = Scene()
             ctx = GameContext(s, InputState())
@@ -4525,7 +4473,7 @@ using StaticArrays
         end
 
         @testset "spawned entity has components after apply_mutations!" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             s = Scene()
             ctx = GameContext(s, InputState())
@@ -4536,7 +4484,7 @@ using StaticArrays
         end
 
         @testset "despawn removes entity from scene" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             s = scene([entity([TransformComponent()])])
             eid = s.entities[1]
@@ -4547,7 +4495,7 @@ using StaticArrays
         end
 
         @testset "despawn removes entity components from ECS" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             s = scene([entity([TransformComponent()])])
             eid = s.entities[1]
@@ -4558,7 +4506,7 @@ using StaticArrays
         end
 
         @testset "apply_mutations! on empty queues preserves entity count" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             s = scene([entity([TransformComponent()])])
             initial_count = entity_count(s)
@@ -4568,7 +4516,7 @@ using StaticArrays
         end
 
         @testset "two spawn! calls return different EntityIDs" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             s = Scene()
             ctx = GameContext(s, InputState())
@@ -4683,11 +4631,11 @@ using StaticArrays
     end
 
     @testset "Prefab" begin
-        reset_entity_counter!()
+        
         reset_component_stores!()
 
         @testset "instantiate calls factory with correct kwargs" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             pf = Prefab(; position=Vec3d(0,0,0)) do (; position)
                 entity([TransformComponent(; position)])
@@ -4698,7 +4646,7 @@ using StaticArrays
         end
 
         @testset "spawn!(ctx, prefab) returns a valid EntityID" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             pf = Prefab(; position=Vec3d(0,0,0)) do (; position)
                 entity([TransformComponent(; position)])
@@ -4711,7 +4659,7 @@ using StaticArrays
         end
 
         @testset "two spawns from same prefab produce different EntityIDs" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             pf = Prefab(; position=Vec3d(0,0,0)) do (; position)
                 entity([TransformComponent(; position)])
@@ -4724,7 +4672,7 @@ using StaticArrays
         end
 
         @testset "after apply_mutations! both entities exist in scene" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             pf = Prefab(; position=Vec3d(0,0,0)) do (; position)
                 entity([TransformComponent(; position)])
@@ -4739,7 +4687,7 @@ using StaticArrays
         end
 
         @testset "override kwargs reflected in spawned entity components" begin
-            reset_entity_counter!()
+            
             reset_component_stores!()
             pf = Prefab(; position=Vec3d(0,0,0)) do (; position)
                 entity([TransformComponent(; position)])


### PR DESCRIPTION
Hi @sinisterMage, I tried to help integrating Ark.jl into Open-Reality.

Consider though that I don't think this is what you want in full, though I think that starting from this, you should be able to easily change the things you are interested in. There are also some usage of Ark internals, which can be avoided, but to move fast, I just used them, but also those should be easy to avoid. I encourage you to change anything you'd like at this stage. I think also that a lot of stuff can be improved. Tests should pass, but I had some failures even before applying the changes, so it is possible that there are some fails even when all rendering backends are correctly imported. Also, I didn't update docs.

Benchmarks are already much better (though still not as good as using Ark directly):

```julia
julia> using OpenReality, BenchmarkTools
Precompiling OpenReality finished.
  1 dependency successfully precompiled in 7 seconds. 227 already precompiled.

julia> struct Position <: Component
           x::Float64
           y::Float64
       end

julia> struct Velocity <: Component
           vx::Float64
           vy::Float64
       end

julia> const NewWorld = initialize_world([Position, Velocity])
World(entities=0, comp_types=(Position, Velocity, AnimationComponent, AnimationBlendTreeComponent, AudioListenerComponent, AudioSourceComponent, CameraComponent, ThirdPersonCamera, OrbitCamera, CinematicCamera, ColliderComponent, PointLightComponent, DirectionalLightComponent, IBLComponent, LODComponent, MaterialComponent, MeshComponent, ParticleSystemComponent, PlayerComponent, RigidBodyComponent, ScriptComponent, BoneComponent, SkinnedMeshComponent, TerrainComponent, TransformComponent, JointComponent, TriggerComponent, CollisionCallbackComponent))

julia> OpenReality.World() = NewWorld

julia> function new_entity!(world, components::Tuple)
           e = create_entity!(world)
           for c in components
               add_component!(e, c)
           end
           return e
       end
new_entity! (generic function with 1 method)

julia> function setup_world(n_entities::Int)
           world = World()
           entities = Vector{EntityID}()
           for i in 1:n_entities
               e = new_entity!(world, (Position(Float64(i), Float64(i * 2)),))
               push!(entities, e)
           end
           return (entities, world)
       end
setup_world (generic function with 1 method)

julia> function benchmark_world_get_1(entities, world)
           sum = 0.0
           for e in entities
               pos = get_component(e, Position)
               sum += pos.x
           end
           return sum
       end
benchmark_world_get_1 (generic function with 1 method)

julia> function benchmark_world_set_1(entities, world)
           for e in entities
               add_component!(e, Position(1.0, 2.0))
           end
       end
benchmark_world_set_1 (generic function with 1 method)

julia> function benchmark_world_add_remove_1(entities, world)
           for e in entities
               add_component!(e, Velocity(0.0, 0.0))
           end
           for e in entities
               remove_component!(e, Velocity)
           end
       end
benchmark_world_add_remove_1 (generic function with 1 method)

julia> e, w = setup_world(10^5);

julia> @benchmark benchmark_world_get_1($e, $w)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  118.904 μs … 185.910 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     125.286 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   127.737 μs ±   6.362 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▁     ▂▅▇█▆▆▁▁▄▅▅▄▃▁▁▁▂▂▂▂▂▁▁▁▁▁▁                             ▂
  █▇▃▅▆██████████████████████████████▇█▇▇▇▇▇▇▇▆▇▆▇▆▇▆▆▆▆▆▅▅▆▅▃▅ █
  119 μs        Histogram: log(frequency) by time        155 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark benchmark_world_set_1($e, $w)
BenchmarkTools.Trial: 4266 samples with 1 evaluation per sample.
 Range (min … max):  757.856 μs …  1.426 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):       1.201 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.170 ms ± 77.008 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                                       ▁▄█▂     
  ▂▂▁▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▃▂▃▂▃▃▂▃▃▃▃▄▄▃▃▃▃▄▄▄▅▅▆▇████▇▄▃ ▃
  758 μs          Histogram: frequency by time         1.25 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark benchmark_world_add_remove_1($e, $w)
BenchmarkTools.Trial: 873 samples with 1 evaluation per sample.
 Range (min … max):  5.514 ms …  6.150 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.726 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.725 ms ± 46.382 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                 ▁▄▃▃▇▇▇██▇█▇▄▇▄▂▃▂           
  ▃▁▁▁▁▁▁▁▁▁▂▁▂▁▁▂▁▂▃▃▂▃▁▄▄▄▆▆▇█▆███████████████████▆▄▆▅▄▂▁▃ ▄
  5.51 ms        Histogram: frequency by time        5.82 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

unfortunately I'm a bit tight on time, so if you can help out, please do!